### PR TITLE
add print in request_with_retry

### DIFF
--- a/src/monday_retry/monday.py
+++ b/src/monday_retry/monday.py
@@ -32,6 +32,7 @@ class Monday:
         if 'errors' not in response:
             return response
         else:
+            print('🚨 retry errors', response)
             self._mixpanel_logger('Complexity')
             return {'errors': response, 'delay': self._extract_delay_from_api_response(response['errors'])}
 


### PR DESCRIPTION
Added more context when a retry fails. Also, something I noticed that we can fix later is that:

![image](https://user-images.githubusercontent.com/25943796/172495877-a5e8abff-3c3b-4bd5-9c7d-c18e97069ce9.png)

This error can be a string and not a dict. And the highlighted raises an error in that case.
